### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,18 @@
-name: Main CI script
+name: Build
 on:
   push:
     branches:
-      - "main"
+      - "master"
       - "github-actions" # dedicated branch for testing GH Actions workflow
   pull_request:
     branches:
-      - "main"
+      - "master"
 
 jobs:
   build:
     strategy:
       matrix:
-        node-version: [18.x, 19.x]
+        node-version: [18, 19]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     runs-on: ubuntu-latest
     steps:
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
       - name: Install dependencies
         run: yarn
       - name: Build app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Save build artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: dist-node${{ matrix.node-version }}
+          name: urban-planning-app-node${{ matrix.node-version }}
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [18, 19]
+        node-version: [14, 16, 18, 19]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     runs-on: ubuntu-latest
     steps:
@@ -30,4 +30,5 @@ jobs:
       - name: Save build artifacts
         uses: actions/upload-artifact@v3
         with:
+          name: dist-node${{ matrix.node-version }}
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+      - "github-actions" # dedicated branch for testing GH Actions workflow
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Main CI script
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        node-version: [18.x, 19.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn
+      - name: Build app
+        run: yarn build
+      - name: Save build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist


### PR DESCRIPTION
Added a basic GH Actions workflow for building the app over various [supported Node versions](https://github.com/nodejs/release#release-schedule).

Note: if in the future we need to modify the workflow files, name the branch with `github-actions`