### PR TITLE
feat: add initial canvas to app

### DIFF
--- a/apps/vite/src/App.tsx
+++ b/apps/vite/src/App.tsx
@@ -1,12 +1,27 @@
+import { useState } from "react";
+
+import Canvas from "./components/Canvas";
+import AppStateContext from "./context/AppStateContext";
+import { getDefaultAppState } from "./defaults";
+import { type AppState } from "./types";
 import { TRPCProvider } from "./utils/api";
 
 function App() {
+  const [appState, setAppState] = useState<AppState>(getDefaultAppState());
+
   return (
-    <TRPCProvider>
-      <div className="flex h-screen w-screen items-center justify-center bg-white">
-        <h1>Yay</h1>
-      </div>
-    </TRPCProvider>
+    <>
+      {" "}
+      <TRPCProvider>
+        <AppStateContext.Provider
+          value={{ context: appState, setContext: setAppState }}
+        >
+          <div className="flex h-screen w-screen items-center justify-center bg-white">
+            <Canvas />
+          </div>
+        </AppStateContext.Provider>
+      </TRPCProvider>
+    </>
   );
 }
 

--- a/apps/vite/src/components/Canvas.tsx
+++ b/apps/vite/src/components/Canvas.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef } from "react";
+
+const Canvas = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // const canvasScale = window.devicePixelRatio;
+
+  // const canvasHeight = 800 * canvasScale; // temporarily hardcoded values
+  // const canvasWidth = 800 * canvasScale; // temporarily hardcoded values
+
+  const handleContextMenu: (event: React.MouseEvent) => void = (
+    event: React.MouseEvent,
+  ) => {
+    console.warn("handleContextMenu triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const handlePointerDown: (event: React.PointerEvent) => void = (
+    event: React.PointerEvent,
+  ) => {
+    console.warn("handlePointerDown triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const handleDoubleClick: (event: React.MouseEvent) => void = (
+    event: React.MouseEvent,
+  ) => {
+    console.warn("handleDoubleClick triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const handlePointerMove: (event: React.PointerEvent) => void = (
+    event: React.PointerEvent,
+  ) => {
+    console.warn("handlePointerMove triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const handlePointerUp: (event: React.PointerEvent) => void = (
+    event: React.PointerEvent,
+  ) => {
+    console.warn("handlePointerUp triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const removePointer: (event: React.PointerEvent) => void = (
+    event: React.PointerEvent,
+  ) => {
+    console.warn("removePointer triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const handleTouchMove: (
+    event: React.TouchEvent<HTMLCanvasElement>,
+  ) => void = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    console.warn("handleTouchMove triggered - NOT YET IMPLMENTED");
+    return;
+  };
+
+  const draw: () => void = () => {
+    const canvas = canvasRef.current;
+    const GRID_SIZE = 50;
+
+    if (canvas === null) return;
+
+    const ctx = canvas.getContext("2d");
+
+    if (ctx === null) return;
+
+    const left = 0.5 - Math.ceil(canvas.width / GRID_SIZE) * GRID_SIZE;
+    const top = 0.5 - Math.ceil(canvas.height / GRID_SIZE) * GRID_SIZE;
+    const right = 2 * canvas.width;
+    const bottom = 2 * canvas.height;
+
+    ctx.clearRect(left, top, right - left, bottom - top);
+    ctx.beginPath();
+
+    for (let x = left; x < right; x += GRID_SIZE) {
+      ctx.moveTo(x, top);
+      ctx.lineTo(x, bottom);
+    }
+
+    for (let y = top; y < bottom; y += GRID_SIZE) {
+      ctx.moveTo(left, y);
+      ctx.lineTo(right, y);
+    }
+
+    ctx.strokeStyle = "#888";
+    ctx.stroke();
+  };
+
+  useEffect(() => {
+    draw();
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        background: "silver",
+      }}
+      onContextMenu={handleContextMenu}
+      onPointerDown={handlePointerDown}
+      onDoubleClick={handleDoubleClick}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={removePointer}
+      onTouchMove={handleTouchMove}
+    ></canvas>
+  );
+};
+
+export default Canvas;

--- a/apps/vite/src/context/AppStateContext.ts
+++ b/apps/vite/src/context/AppStateContext.ts
@@ -1,0 +1,21 @@
+import { createContext, type Dispatch, type SetStateAction } from "react";
+
+import { getDefaultAppState } from "../defaults";
+import { type AppState } from "../types";
+
+type AppStateContextType = {
+  context: AppState;
+  setContext: Dispatch<SetStateAction<AppState>>;
+};
+
+const AppStateContextState = {
+  context: getDefaultAppState(),
+  setContext: () => {
+    console.warn("unitialized setAppState context!");
+  },
+};
+
+const AppStateContext =
+  createContext<AppStateContextType>(AppStateContextState);
+
+export default AppStateContext;

--- a/apps/vite/src/defaults.ts
+++ b/apps/vite/src/defaults.ts
@@ -1,0 +1,7 @@
+import { type AppState } from "./types";
+
+export const getDefaultAppState: () => AppState = () => {
+  return {
+    name: "untitled",
+  };
+};

--- a/apps/vite/src/types.ts
+++ b/apps/vite/src/types.ts
@@ -1,0 +1,3 @@
+export type AppState = {
+  name: string;
+};


### PR DESCRIPTION
The canvas does not yet draw anything, neither is it an infinite canvas.

The canvas is there and it has handlers (not-implemented of course) for all the mouse events that we will need down the line.

Here is what is currently implmented:

- State that will be used for the project
- A grid like layout
- Pretty much all the boiler plate that you will need to implement canvas-related features without tying you down to a certain way of using the canvas.

Here is what is yet to be done:

- State/context to store the drawn items
- Styling of the canvas
- It being an infinite canvas.
- currently it just renders the canvas once and never after. This has been *intentionally* been left out as this is a big design challenge and something that we should think well about before doing.
